### PR TITLE
Fix `run_exports`

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -5,7 +5,7 @@ arm_variant_type:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
   sha256: 2e97727ea5c943d0757e564fe87818a5c8c3d27bc78d60a7aaab8874e3ec5960  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx]
 
 test:
@@ -64,6 +64,9 @@ outputs:
       doc_url: https://docs.nvidia.com/cuda/nvrtc/
 
   - name: cuda-nvrtc-dev
+    build:
+      run_exports:
+        - {{ pin_subpackage("cuda-nvrtc", max_pin="x") }}
     files:
       - lib/libnvrtc*.so                            # [linux]
       - lib/pkgconfig                               # [linux]


### PR DESCRIPTION
This fixes the warning seen in https://github.com/conda-forge/cupy-feedstock/pull/199.
```
WARNING (cupy,lib/python3.10/site-packages/cupy_backends/cuda/libs/nvrtc.cpython-310-x86_64-linux-gnu.so): Needed DSO lib/libnvrtc.so.12 found in ['cuda-nvrtc']
WARNING (cupy,lib/python3.10/site-packages/cupy_backends/cuda/libs/nvrtc.cpython-310-x86_64-linux-gnu.so): .. but ['cuda-nvrtc'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
```
cc: @adibbley @jakirkham 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
